### PR TITLE
proposed fixes for negative tz and 12hr clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,13 +518,13 @@ Year = ( y >> 3 ) & 0x1F
 
 ### Flashing from Arduino IDE
 
-- Clone source code, open file can-clock/can-clock.info
+- Clone source code, open file can-clock/can-clock.ino
 - Select proper hardware (SparkFun Pro Micro, 5V)
 - Compile and upload
 
 ### Flashing from Platform IO/Atom
 
-- Clone source code, open file can-clock/can-clock.info
+- Clone source code, open file can-clock/can-clock.ino
 - Open PlatformIO project
 - Run task PIO Build (sparkfun_micro16)
 - Run task PIO Upload (sparkfun_micro16)

--- a/README.md
+++ b/README.md
@@ -395,8 +395,8 @@ flags:
 0x80 - time is adjusting (blink)
 0xA0 - AM
 0xC0 - PM
-0xE0 - 24 hours
-0xC0 - clock off
+0xF0 - 24 hours
+0x00 - clock off
 
 **Special cases**
 

--- a/can-clock/Service.h
+++ b/can-clock/Service.h
@@ -32,9 +32,11 @@ String readSerialString()
 
 uint8_t Day_of_Week(const uint16_t yr, const uint8_t m, const uint8_t d)
 {
+  uint8_t weekday;
   uint8_t t[] = {0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4};
   uint16_t y = yr - m < 3;
-  return( (y + y/4 - y/100 + y/400 + t[m-1] + d) % 7 );
+  weekday = (y + y/4 - y/100 + y/400 + t[m-1] + d) % 7;
+  return(weekday);
 }
 
 #endif // __SERVICE_H_

--- a/can-clock/Service.h
+++ b/can-clock/Service.h
@@ -30,4 +30,11 @@ String readSerialString()
   return(inSerialData);
 }
 
+unit8_t Day_of_Week(const unit8_t y, const unit8_t m, const unit8_t d)
+{
+  uint8_t t[] = {0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4};
+  y -= m < 3;
+  return( (y + y/4 - y/100 + y/400 + t[m-1] + d) % 7 );
+}
+
 #endif // __SERVICE_H_

--- a/can-clock/Service.h
+++ b/can-clock/Service.h
@@ -30,10 +30,10 @@ String readSerialString()
   return(inSerialData);
 }
 
-unit8_t Day_of_Week(const unit8_t y, const unit8_t m, const unit8_t d)
+uint8_t Day_of_Week(const uint8_t yr, const uint8_t m, const uint8_t d)
 {
   uint8_t t[] = {0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4};
-  y -= m < 3;
+  uint8_t y = yr - m < 3;
   return( (y + y/4 - y/100 + y/400 + t[m-1] + d) % 7 );
 }
 

--- a/can-clock/Service.h
+++ b/can-clock/Service.h
@@ -30,10 +30,10 @@ String readSerialString()
   return(inSerialData);
 }
 
-uint8_t Day_of_Week(const uint8_t yr, const uint8_t m, const uint8_t d)
+uint8_t Day_of_Week(const uint16_t yr, const uint8_t m, const uint8_t d)
 {
   uint8_t t[] = {0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4};
-  uint8_t y = yr - m < 3;
+  uint16_t y = yr - m < 3;
   return( (y + y/4 - y/100 + y/400 + t[m-1] + d) % 7 );
 }
 

--- a/can-clock/Settings.h
+++ b/can-clock/Settings.h
@@ -62,7 +62,7 @@ void readSettings() {
 
 void saveSettings() {
   for (unsigned int t=0; t<sizeof(currentSettings); t++)
-   EEPROM.write(CONFIG_START + t, *((char*)&currentSettings + t));
+   EEPROM.update(CONFIG_START + t, *((char*)&currentSettings + t));
 
   isConfigured = true;
 }

--- a/can-clock/Settings.h
+++ b/can-clock/Settings.h
@@ -36,7 +36,7 @@ typedef struct __attribute__((__packed__)) {
   int8_t tz;
   bool tpmsRequest;
   uint8_t huType;
-  bool spare2;
+  bool DST;
   bool spare3;
 } Settings;
 
@@ -50,7 +50,7 @@ Settings currentSettings = {
   3,              // tz
   true,           // tpmsRequest
   HU_AFTERMARKET, // huType
-  false,          // spare2
+  false,          // DST
   false           // spare3
 };
 

--- a/can-clock/Settings.h
+++ b/can-clock/Settings.h
@@ -172,7 +172,7 @@ void settingsMenu() {
     currentSettings.huType = HU_CHINESE_WITH_CAN_EXTENDED;
   }
 
-  Serial.println(F("Select time source\n1 - 911 Assist GPS (2010+)\n2 - controller real time clock\n"));
+  Serial.println(F("\n\nSelect time source\n1 - 911 Assist GPS (2010+)\n2 - controller real time clock\n"));
 
   input = readSerialString();
 
@@ -184,7 +184,7 @@ void settingsMenu() {
 
   if (currentSettings.useRTC) {
     printCurrentRTCTime();
-    Serial.println(F("Enter local time in 24h format (HH:MM) or Enter to keep as is"));
+    Serial.println(F("\n\nEnter local time in 24h format (HH:MM) or Enter to keep as is"));
     input = readSerialString();
     Serial.println(input);
     if (!input.equals("")) {
@@ -196,12 +196,12 @@ void settingsMenu() {
       printCurrentRTCTime();
     }
   } else {
-    Serial.println(F("Enter timezone (+- hours)\n"));
+    Serial.println(F("\n\nEnter timezone (+- hours)\n"));
     input = readSerialString();
     currentSettings.tz = input.toInt();
   }
 
-  Serial.println(F("Set clock mode\n1 - Hide\n2 - 12h\n3 - 24h"));
+  Serial.println(F("\n\nSet clock mode\n1 - Hide\n2 - 12h\n3 - 24h"));
   input = readSerialString();
   if (input.equals("1")) {
     currentSettings.clockMode = CLOCK_HIDE;
@@ -211,7 +211,7 @@ void settingsMenu() {
     currentSettings.clockMode = CLOCK_24;
   }
 
-  Serial.println(F("Select speed/temperature units\n1 - Metric\n2 - American\n"));
+  Serial.println(F("\n\nSelect speed/temperature units\n1 - Metric\n2 - American\n"));
   input = readSerialString();
 
   if (input.equals("1")) {
@@ -220,7 +220,7 @@ void settingsMenu() {
     currentSettings.unitsMetric = false;
   }
 
-  Serial.println(F("Display tires pressure\n1 - Yes\n2 - No\n"));
+  Serial.println(F("\n\nDisplay tires pressure\n1 - Yes\n2 - No\n"));
   input = readSerialString();
 
   if (input.equals("1")) {
@@ -230,7 +230,7 @@ void settingsMenu() {
   }
 
   if (currentSettings.displayPressure) {
-    Serial.println(F("Pressure units\n1 - Psi\n2 - kPa\n3 - Bars\n"));
+    Serial.println(F("\n\nPressure units\n1 - Psi\n2 - kPa\n3 - Bars\n"));
 
     input = readSerialString();
 
@@ -243,7 +243,7 @@ void settingsMenu() {
     }
   }
 
-  Serial.println(F("Set TPMS interaction mode\n1 - Request\n2 - Broadcast"));
+  Serial.println(F("\n\nSet TPMS interaction mode\n1 - Request\n2 - Broadcast"));
   input = readSerialString();
   if (input.equals("1")) {
     currentSettings.tpmsRequest = true;
@@ -251,7 +251,7 @@ void settingsMenu() {
     currentSettings.tpmsRequest = false;
   }
 
-  Serial.println(F("Saving settings...\n\n"));
+  Serial.println(F("\n\nSaving settings...\n\n"));
   saveSettings();
   Serial.println(F("Settings saved, getting back to operation mode"));
 }

--- a/can-clock/Settings.h
+++ b/can-clock/Settings.h
@@ -33,7 +33,7 @@ typedef struct __attribute__((__packed__)) {
   bool displayPressure;
   bool unitsMetric;
   uint8_t clockMode;
-  uint8_t tz;
+  int8_t tz;
   bool tpmsRequest;
   uint8_t huType;
   bool spare2;

--- a/can-clock/can-clock.ino
+++ b/can-clock/can-clock.ino
@@ -391,7 +391,7 @@ void loop() {
       gotClock = true;
     }
 
-    if (currentsettings.clockMode == CLOCK_12) {
+    if (currentSettings.clockMode == CLOCK_12) {
       AM = (hour < 12);
       hour = hour % currentSettings.clockMode;
       if (hour == 0) {
@@ -415,7 +415,7 @@ void loop() {
           cycle[currentCycle].data[3] = month;
           cycle[currentCycle].data[4] = year;
           
-          if (currentsettings.clockMode == CLOCK_12) {
+          if (currentSettings.clockMode == CLOCK_12) {
             cycle[currentCycle].data[5] = (0xA0 + (32 * AM));
           }
         }

--- a/can-clock/can-clock.ino
+++ b/can-clock/can-clock.ino
@@ -434,11 +434,11 @@ void loop() {
     else if (dow == 0 && month == 11 && hour > 1 && currentSettings.DST == true)  //set DST off for US, +0 after 1st Sunday of November @ 2 AM
       EEPROM.update(CONFIG_START + 9, false);
     
-    hour = hour + currentSettings.DST;  //Add DST hour if needed
+    hour += currentSettings.DST;  //Add DST hour if needed
 
-    if (currentSettings.clockMode == CLOCK_12) {
+    if (currentSettings.clockMode == CLOCK_12) {  //Change to 12 hour display
       AM = (hour < 12);
-      hour = hour % currentSettings.clockMode;
+      hour %= 12;
       if (hour == 0) hour = 12;
     }
 

--- a/can-clock/can-clock.ino
+++ b/can-clock/can-clock.ino
@@ -394,10 +394,10 @@ void loop() {
     dow = Day_of_Week(year, month, date);
     
     if (dow == 0 && month == 3 && date >= 8 && hour > 1 && currentSettings.DST == false)  //set DST on for US, +1 after 2nd Sunday of March @ 2 AM
-      EEPROM.update(CONFIG_START + 10, true);
+      EEPROM.update(CONFIG_START + 9, true);
     
     else if (dow == 0 && month == 11 && hour > 1 && currentSettings.DST == true)  //set DST off for US, +0 after 1st Sunday of November @ 2 AM
-      EEPROM.update(CONFIG_START + 10, false);
+      EEPROM.update(CONFIG_START + 9, false);
     
     hour = hour + currentSettings.DST;  //Add DST hour if needed
 

--- a/can-clock/can-clock.ino
+++ b/can-clock/can-clock.ino
@@ -357,7 +357,7 @@ void loop() {
           break;
         case 0x466: {  // GPS clock
             if (!currentSettings.useRTC && (currentSettings.clockMode != CLOCK_HIDE)) {
-              hour = (((rcvBuf[0] & 0xF8) >> 3) + currentSettings.tz ) % currentSettings.clockMode;
+              hour = (bcdToDec(((rcvBuf[0] & 0xF8) >> 3)) + currentSettings.tz ) % currentSettings.clockMode;
               minute = (rcvBuf[1] & 0xFC) >> 2;
               second = (rcvBuf[2] & 0xFC) >> 2;
               gotClock = true;

--- a/can-clock/can-clock.ino
+++ b/can-clock/can-clock.ino
@@ -416,7 +416,7 @@ void loop() {
           cycle[currentCycle].data[4] = year;
           
           if (currentSettings.clockMode == CLOCK_12) {
-            cycle[currentCycle].data[5] = (0xA0 + (32 * AM));
+            cycle[currentCycle].data[5] = (0xC0 - (32 * AM));
           }
         }
 

--- a/can-clock/can-clock.ino
+++ b/can-clock/can-clock.ino
@@ -22,7 +22,7 @@
 const uint8_t TIMER_STEP = 25;
 const uint8_t SPI_CS_PIN = 10;
 
-uint8_t second, minute, hour, date, month, year;
+uint8_t second, minute, hour, date, dow, month, year;
 uint8_t i,filtNo;
 
 #if !defined(__AVR_ATmega32U4__) // not Arduino Pro Micro
@@ -390,6 +390,14 @@ void loop() {
       clockMessage = hourString.padZeros(2) + F(":") + minuteString.padZeros(2);
       gotClock = true;
     }
+
+    dow = Day_of_Week(year, month, day)
+    if (dow == 0 && month == 3 && date >= 8 && hour > 1 && currentSettings.DST == false)  //DST on for US, +1 after 2nd Sunday of March @ 2 AM
+      EEPROM.update(CONFIG_START + 10, true);
+    else if (dow == 0 && month == 11 && hour > 1 && currentSettings.DST == true)  //DST off for US, +0 after 1st Sunday of November @ 2 AM
+      EEPROM.update(CONFIG_START + 10, false);
+      
+    hour = hour + currentSettings.DST;  //Add DST hour if needed
 
     if (currentSettings.clockMode == CLOCK_12) {
       AM = (hour < 12);

--- a/can-clock/can-clock.ino
+++ b/can-clock/can-clock.ino
@@ -391,12 +391,14 @@ void loop() {
       gotClock = true;
     }
 
-    dow = Day_of_Week(year, month, day)
-    if (dow == 0 && month == 3 && date >= 8 && hour > 1 && currentSettings.DST == false)  //DST on for US, +1 after 2nd Sunday of March @ 2 AM
+    dow = Day_of_Week(year, month, date);
+    
+    if (dow == 0 && month == 3 && date >= 8 && hour > 1 && currentSettings.DST == false)  //set DST on for US, +1 after 2nd Sunday of March @ 2 AM
       EEPROM.update(CONFIG_START + 10, true);
-    else if (dow == 0 && month == 11 && hour > 1 && currentSettings.DST == true)  //DST off for US, +0 after 1st Sunday of November @ 2 AM
+    
+    else if (dow == 0 && month == 11 && hour > 1 && currentSettings.DST == true)  //set DST off for US, +0 after 1st Sunday of November @ 2 AM
       EEPROM.update(CONFIG_START + 10, false);
-      
+    
     hour = hour + currentSettings.DST;  //Add DST hour if needed
 
     if (currentSettings.clockMode == CLOCK_12) {

--- a/can-clock/can-clock.ino
+++ b/can-clock/can-clock.ino
@@ -382,7 +382,7 @@ void loop() {
       DateTime now = rtc.now();
       year = now.year();
       month = now.month();
-      date = now.day();
+      date = now.date();
       hour = now.hour();
       minute = now.minute();
       hourString = String(hour);

--- a/can-clock/can-clock.ino
+++ b/can-clock/can-clock.ino
@@ -357,7 +357,7 @@ void loop() {
           break;
         case 0x466: {  // GPS clock
             if (!currentSettings.useRTC && (currentSettings.clockMode != CLOCK_HIDE)) {
-              hour = (bcdToDec(((rcvBuf[0] & 0xF8) >> 3)) + currentSettings.tz ) % currentSettings.clockMode;
+              hour = (((rcvBuf[0] & 0xF8) >> 3) + currentSettings.tz ) % currentSettings.clockMode;
               minute = (rcvBuf[1] & 0xFC) >> 2;
               second = (rcvBuf[2] & 0xFC) >> 2;
               gotClock = true;

--- a/can-clock/can-clock.ino
+++ b/can-clock/can-clock.ino
@@ -361,13 +361,12 @@ void loop() {
           break;
         case 0x466: {  // GPS clock
             if (!currentSettings.useRTC && (currentSettings.clockMode != CLOCK_HIDE)) {
-              hour = (((rcvBuf[0] & 0xF8) >> 3) + currentSettings.tz) % 24;
+              hour = (((rcvBuf[0] & 0xF8) >> 3) + currentSettings.tz);
               minute = (rcvBuf[1] & 0xFC) >> 2;
               second = (rcvBuf[2] & 0xFC) >> 2;
-              date = (rcvBuf[4] & 0xFC) >> 2; // FIXME: needs tz correction
-              month = (rcvBuf[5] & 0xFC) >> 2; //FIXME: needs tz correction
+              date = (rcvBuf[4] & 0xFC) >> 2;
+              month = (rcvBuf[5] & 0xFC) >> 2;
               year = ((rcvBuf[6] & 0xF0) >> 4) + 2010; //FIXME: not sure if + 2010 is correct & needs tz correction
-              if (hour < 0) hour = hour + 24; // fixed for negative tz
               gotClock = true;
               
               if (year % 4 == 0)       // need to account for leapyear, good until the year 2100

--- a/can-clock/can-clock.ino
+++ b/can-clock/can-clock.ino
@@ -359,7 +359,7 @@ void loop() {
           break;
         case 0x466: {  // GPS clock
             if (!currentSettings.useRTC && (currentSettings.clockMode != CLOCK_HIDE)) {
-              hour = ((rcvBuf[0] & 0xF8) >> 3) + currentSettings.tz;
+              hour = (((rcvBuf[0] & 0xF8) >> 3) + currentSettings.tz) % 24;
               minute = (rcvBuf[1] & 0xFC) >> 2;
               second = (rcvBuf[2] & 0xFC) >> 2;
               date = (rcvBuf[4] & 0xFC) >> 2; // FIXME: needs tz correction

--- a/can-clock/can-clock.ino
+++ b/can-clock/can-clock.ino
@@ -384,6 +384,9 @@ void loop() {
       gotClock = true;
     }
 
+    if (hour == 0 && currentSettings.clockMode == CLOCK_12)
+      hour = 12;
+
     for (uint16_t currentCycle = 0; currentCycle < MSG_COUNT; currentCycle++ ) {
       if ( ( (timer >= cycle[currentCycle].started ) || (!firstCycle) ) && ((timer % cycle[currentCycle].repeated) - cycle[currentCycle].delayed) == 0) {
 

--- a/can-clock/can-clock.ino
+++ b/can-clock/can-clock.ino
@@ -411,9 +411,9 @@ void loop() {
                // init functions if stock head unit is used, so no extra checks
           cycle[currentCycle].data[0] = decToBcd(hour);
           cycle[currentCycle].data[1] = decToBcd(minute);
-          cycle[currentCycle].data[2] = date;
-          cycle[currentCycle].data[3] = month;
-          cycle[currentCycle].data[4] = year;
+          cycle[currentCycle].data[2] = decToBcd(date);
+          cycle[currentCycle].data[3] = decToBcd(month);
+          cycle[currentCycle].data[4] = decToBcd(year);
           
           if (currentSettings.clockMode == CLOCK_12) {
             cycle[currentCycle].data[5] = (0xC0 - (32 * AM));


### PR DESCRIPTION
Not a coder, so feel free to correct or clean up. Thx for all the work, hope this helps!
Issue #1 :
changed **tz** to **_int8_t_** so that negative values are preserved.

Added spacing to **settings menu**.

Issue #2 :
added new bool value for **AM**
moved **_hour % clockMode_** to an if statement
wrote AM/PM Byte, if using 12 hr Mode

Issue #3 :
Edit: added the flags description fix for the ReadMe

Issue #5 : 
added date, month, year  in preparation for automatic DST adjustment coming later.